### PR TITLE
Use docker buildx to create multiplatform builds

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,2 @@
-docker build . -t devforth/spa-to-http:latest
-docker push devforth/spa-to-http:latest
-
-docker build . -t devforth/spa-to-http:1.0.3
-docker push devforth/spa-to-http:1.0.3
+docker buildx create --use
+docker buildx build --platform=linux/amd64,linux/arm64 --tag "devforth/spa-to-http:latest" --tag "devforth/spa-to-http:1.0.3" --push .


### PR DESCRIPTION
I was not able to use this image without having to emulate the amd64-structure on a mac-m1, so I checked around and saw that it should be possible to create a images that works for both platforms if you change the publish-script a little bit.
Please check it out and see if it is any good :)