### PR TITLE
Implemented a new NoCompress option

### DIFF
--- a/src/app/app.go
+++ b/src/app/app.go
@@ -55,7 +55,7 @@ func NewApp(params *param.Params) App {
 	return App{params: params, server: nil, cache: cache}
 }
 
-func (app *App) shouldSkipCompression(filePath string) bool {
+func (app *App) ShouldSkipCompression(filePath string) bool {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	for _, blocked := range app.params.NoCompress {
 		if strings.ToLower(blocked) == ext {
@@ -83,7 +83,7 @@ func (app *App) CompressFiles() {
 			return nil
 		}
 
-		if app.shouldSkipCompression(filePath) {
+		if app.ShouldSkipCompression(filePath) {
 			return nil
 		}
 
@@ -245,7 +245,7 @@ func (app *App) HandlerFuncNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Range") != "" || app.shouldSkipCompression(requestedPath) {
+	if r.Header.Get("Range") != "" || app.ShouldSkipCompression(requestedPath) {
 		if responseItem.ContentType != "" {
 			w.Header().Set("Content-Type", responseItem.ContentType)
 		}

--- a/src/param/param.go
+++ b/src/param/param.go
@@ -80,6 +80,11 @@ var Flags = []cli.Flag{
 		Name:    "log-pretty",
 		Value:   false,
 	},
+	&cli.StringSliceFlag{
+		EnvVars: []string{"NO_COMPRESS"},
+		Name:    "no-compress",
+		Value:   nil,
+	},
 }
 
 type Params struct {
@@ -96,6 +101,7 @@ type Params struct {
 	CacheBuffer             int
 	Logger                  bool
 	LogPretty               bool
+	NoCompress              []string
 	//DirectoryListing        bool
 }
 
@@ -119,6 +125,7 @@ func ContextToParams(c *cli.Context) (*Params, error) {
 		CacheBuffer:             c.Int("cache-buffer"),
 		Logger:                  c.Bool("logger"),
 		LogPretty:               c.Bool("log-pretty"),
+		NoCompress:              c.StringSlice("no-compress"),
 		//DirectoryListing:        c.Bool("directory-listing"),
 	}, nil
 }


### PR DESCRIPTION
I've added a new option called "NoCompress". This option allows users to specify which file extensions should be excluded from compression, such as videos or other specific file types. This enhancement provides greater flexibility in managing compression settings according to different file requirements.

The option can be renamed to a more explicit one, such as "ExcludeExtensionsFromCompression" or something similar. Personally, I prefer short names, hehe.